### PR TITLE
Updated version for StmCubeIde v1.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@ FROM ${IMAGE} AS base
 RUN apt-get -y update && \
     apt-get -y install zip
 
-COPY en.st-stm32cubeide_1.18.1_24813_20250409_2138_amd64.deb_bundle.sh.zip /tmp/stm32cubeide-installer.sh.zip
+COPY st-stm32cubeide_1.19.0_25607_20250703_0907_amd64.deb_bundle.sh.zip /tmp/stm32cubeide-installer.sh.zip
 
 # Unzip STM32 Cube IDE and delete zip file
 RUN unzip -p /tmp/stm32cubeide-installer.sh.zip > /tmp/stm32cubeide-installer.sh && rm /tmp/stm32cubeide-installer.sh.zip
 
 # Set environment variables and labels in the last tag
 FROM ${IMAGE}
-ENV STM32CUBEIDE_VERSION=1.18.1
+ENV STM32CUBEIDE_VERSION=1.19.0
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LICENSE_ALREADY_ACCEPTED=1
 ENV TZ=Etc/UTC

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Environment docker container.
 To create the image `xanderhendriks/stm32cubeide`, execute the following command in the
 `docker-stm32cubeide` folder:
 
-    docker build -t xanderhendriks/stm32cubeide .
+    docker buildx build -t xanderhendriks/stm32cubeide .
 
 You can now tag the repo and push the changes to the docker hub:
 
-    docker build -t xanderhendriks/stm32cubeide:4.0 .
+    docker buildx build -t xanderhendriks/stm32cubeide:4.0 .
     docker push xanderhendriks/stm32cubeide:4.0
 
 ## Run
@@ -58,6 +58,7 @@ The major.minor version number indicates the version of the underlying [STM32Cub
 - 14.0: STM32 Cube IDE: 1.17.0
 - 15.0: STM32 Cube IDE: 1.18.0
 - 15.1: STM32 Cube IDE: 1.18.1 - Allows running of stm32cubeide GUI on xserver
+- 16.0: STM32 Cube IDE: 1.19.0 - Allows running of stm32cubeide GUI on xserver
 
 NOTE: Bug fixes are only implemented for older versions if requested.
 


### PR DESCRIPTION
Proposed update for support of STM32CubeIde v1.19.0
still need to push the docker image on the public docker registry (I guess only you can do it :) )